### PR TITLE
[FEAT] - 예측처방 페이지 환자목록 클릭시 url 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,10 @@ function App() {
         <Route element={<MainLayout userData={userData} />}>
           <Route path="/main" element={<MainPage />} />
           <Route path="/patient/:patientId/:round" element={<PatientPage />} />
-          <Route path="/prescription" element={<Prescription />} />
+          <Route
+            path="/prescription/:patientId/:round"
+            element={<Prescription />}
+          />
           <Route path="/remark" element={<RemarkPage />} />
           <Route path="/remark/:patientId" element={<RemarkPersonalPage />} />
           <Route path="/settings" element={<SettingPage {...userData} />} />

--- a/src/components/PatientListPage.tsx
+++ b/src/components/PatientListPage.tsx
@@ -2,11 +2,11 @@ import "./PatientListPage.css";
 import PatientsList from "./PatientsList";
 import SectionHeader from "./SectionHeader";
 
-export default function PatientListPage({ usingPage }) {
+export default function PatientListPage() {
   return (
     <div className="patient-list-page__container">
       <SectionHeader title={"Patients"} />
-      <PatientsList usingPage={usingPage} />
+      <PatientsList />
     </div>
   );
 }

--- a/src/components/PatientRow.tsx
+++ b/src/components/PatientRow.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import "./PatientRow.css";
 import InHospitalIcon from "./ui/InHospital";
 
@@ -10,24 +10,12 @@ export default function PatientRow({
   gender = "none",
   inHospital = false,
   index,
-  usingPage,
 }) {
   const nav = useNavigate();
+  const location = useLocation();
+  const pageName = location.pathname.split("/")[1];
   function handleClickPatientRow() {
-    switch (usingPage) {
-      case "remark":
-        nav(`/remark/${name}`);
-        break;
-      case "prescription":
-        nav(`/prescription/${name}`);
-        break;
-      case "patient":
-        nav(`/patient/${id}/1`);
-        break;
-
-      default:
-        break;
-    }
+    nav(`/${pageName}/${id}/1`);
   }
   return (
     <div

--- a/src/components/PatientSummaryCard.tsx.tsx
+++ b/src/components/PatientSummaryCard.tsx.tsx
@@ -1,7 +1,7 @@
 import Button from "./ui/Button";
 import "./PatientSummaryCard.css";
 import SectionHeader from "./SectionHeader";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export default function PatientSummaryCard({
   id,
@@ -11,12 +11,13 @@ export default function PatientSummaryCard({
   gender,
   disease,
   rounds,
-  pageName = "페이지명",
 }) {
   const nav = useNavigate();
+  const location = useLocation();
+  const pageName = location.pathname.split("/")[1];
   function handleChangeOption(e) {
     const address = e.target.value;
-    nav(`/patient/${address}`);
+    nav(`/${pageName}/${address}`);
   }
   return (
     <>

--- a/src/components/PatientsList.tsx
+++ b/src/components/PatientsList.tsx
@@ -2,7 +2,7 @@ import "./PatientsList.css";
 import PatientRow from "./PatientRow";
 import { patients } from "../mocks/patientData";
 
-export default function PatientsList({ usingPage }) {
+export default function PatientsList() {
   return (
     <div className="patients__list__container">
       <div className="patients__list__title">
@@ -12,7 +12,7 @@ export default function PatientsList({ usingPage }) {
       </div>
       <div className="patients__list__list">
         {patients.map((patient, i) => (
-          <PatientRow key={i} {...patient} index={i} usingPage={usingPage} />
+          <PatientRow key={i} {...patient} index={i} />
         ))}
       </div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,8 +25,8 @@ function Menu() {
     <div className="menu__container">
       <MenuContent content="메인" address="/main" />
       <MenuContent content="환자" address="/patient/p001/1" />
-      <MenuContent content="예측처방" address="/prescription" />
-      <MenuContent content="특이사항" address="/remark" />
+      <MenuContent content="예측처방" address="/prescription/p001/1" />
+      <MenuContent content="특이사항" address="/remark/p001/1" />
       <MenuContent content="설정" address="/settings" />
     </div>
   );

--- a/src/mocks/patientData.ts
+++ b/src/mocks/patientData.ts
@@ -8,6 +8,36 @@ export const patients: Patient[] = [
     gender: "여",
     birth: "1964.11.18",
     inHospital: true,
+    bloodTests: [
+      { month: "1월", Ferritin: 80, Iron: 60, PTH: 70, TIBC: 65 },
+      { month: "2월", Ferritin: 60, Iron: 55, PTH: 75, TIBC: 60 },
+      { month: "3월", Ferritin: 85, Iron: 70, PTH: 65, TIBC: 75 },
+    ],
+    hemoglobinLevels: [
+      { month: "4월", Hb: 12 },
+      { month: "5월", Hb: 9.5 },
+      { month: "6월", Hb: 12 },
+    ],
+    hematicRecords: [
+      {
+        date: "Jun 24, 2025",
+        hematic: "에리스로포이에틴",
+        iu: "5000IU",
+        description: "혈압 상승으로 인해 해당 조혈제가 적당함",
+      },
+      {
+        date: "Jun 24, 2025",
+        hematic: "다베포에틴-알파",
+        iu: "5000IU",
+        description: "조혈제 반응이 낮아 용량을 유지함",
+      },
+      {
+        date: "Jun 24, 2025",
+        hematic: "다베포에틴-알파",
+        iu: "10000IU",
+        description: "헤모글로빈 수치 저하로 인해 용량 증량",
+      },
+    ],
     rounds: [
       {
         round: 1,

--- a/src/pages/Patient/PatientPage.tsx
+++ b/src/pages/Patient/PatientPage.tsx
@@ -27,12 +27,11 @@ export default function PatientPage() {
           gender={patient.gender}
           disease={"당뇨병성 신종"}
           rounds={patient.rounds}
-          pageName="환자 정보"
         />
         <PatientDetails {...roundData} />
       </div>
 
-      <PatientListPage usingPage={"patient"} />
+      <PatientListPage />
     </div>
   );
 }

--- a/src/pages/Prescription/PrescriptionPage.tsx
+++ b/src/pages/Prescription/PrescriptionPage.tsx
@@ -1,18 +1,29 @@
+import { useParams } from "react-router-dom";
 import PatientListPage from "../../components/PatientListPage";
 import PatientSummaryCard from "../../components/PatientSummaryCard.tsx";
 import PrescriptionDetails from "./components/PrescriptionDetails.tsx";
 import "./PrescriptionPage.css";
+import { patients } from "../../mocks/patientData.ts";
+
+const patientList = patients; // 임시 환자 데이터
+
 export default function Prescription() {
+  const patientId = useParams().patientId; // PageRow에서 해당 정해진 params로 이동시키고 여기서 받아오는 방식
+  const round = useParams().round;
+  const patient = patientList.filter((p) => p.id === patientId)[0];
+
+  console.log(patient);
   return (
     <div className="prescription__page__container">
       <div className="prescription__main__content">
         <PatientSummaryCard
-          name="정연준"
-          age={18}
-          birth="2002.07.31"
-          sex="남"
+          id={patient.id}
+          name={patient.name}
+          age={patient.age}
+          birth={patient.birth}
+          gender={patient.gender}
           disease={"당뇨병성 신종"}
-          pageName="예측 처방"
+          rounds={patient.rounds}
         />
         <PrescriptionDetails />
       </div>

--- a/src/pages/Prescription/components/PrescriptionTable.tsx
+++ b/src/pages/Prescription/components/PrescriptionTable.tsx
@@ -6,10 +6,11 @@ export default function PrescriptionTable() {
     <div className="prescription__table__container">
       <table className="prescription__table">
         <thead className="prescription__thead">
-          <th>Date</th>
-          <th>Hematinic</th>
-          <th>IU</th>
-          <th>Description</th>
+          <tr>
+            <th>Date</th>
+            <th>Hematinic</th>
+            <th>IU</th>
+          </tr>
         </thead>
         <tbody className="prescription__tbody">
           {prescriptionData.map((data, idx) => (


### PR DESCRIPTION
## #️⃣ Issue Number
#20 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
환자 목록 클릭하면 예측처방 페이지의 해당 환자 해당 회차 url로 이동함
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
